### PR TITLE
Created base AppDbContext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# App DB Configuration files
+AppDbContext.cs

--- a/Barroc-Intens/Barroc-Intens/Barroc-Intens.csproj
+++ b/Barroc-Intens/Barroc-Intens/Barroc-Intens.csproj
@@ -13,6 +13,12 @@
     <UseWinUI>true</UseWinUI>
     <EnableMsixTooling>true</EnableMsixTooling>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="Data\AppDbContext.cs.example" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Data\AppDbContext.cs.example" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -25,8 +31,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-rc.2.24474.1" />
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.240923002" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0-preview.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0-rc.2.24473.5" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>
 

--- a/Barroc-Intens/Barroc-Intens/Data/AppDbContext.cs.example
+++ b/Barroc-Intens/Barroc-Intens/Data/AppDbContext.cs.example
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore; // Important to include, so DbContext gets regionized
+namespace Barroc_Intens.Data
+{
+    internal class AppDbContext : DbContext
+    {
+        // DbSet for each model
+        // Example: public DbSet<User> Users { get; set; }
+
+        // Override OnConfiguring from DbContext
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            optionsBuilder.UseMySql("server=localhost;port=3306;user=root;password=;database=barrocintens",ServerVersion.Parse("8.0.30"));
+            base.OnConfiguring(optionsBuilder);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+
+            base.OnModelCreating(modelBuilder);
+            // Example seed data
+            //modelBuilder.Entity<Message>()
+            //.HasOne(m => m.Chatroom)
+            //.WithMany(c => c.Messages)
+            //.HasForeignKey(m => m.ChatroomId);
+
+            //modelBuilder.Entity<Message>()
+            //    .HasOne(m => m.User)
+            //    .WithMany(u => u.Messages)
+            //    .HasForeignKey(m => m.UserId);
+
+            //modelBuilder.Entity<User>().HasData(
+            //    new User
+            //    {
+            //        Id = 1,
+            //        UserName = "Alice",
+            //        Email = "alice@example.com"
+            //    },
+            //    new User
+            //    {
+            //        Id = 2,
+            //        UserName = "Bob",
+            //        Email = "bob@example.com"
+            //    }
+            //);
+        }
+
+
+    }
+}


### PR DESCRIPTION
Can be used as a base template. Copy the example to AppDbContext.cs, so everyone can (privately) access their database. 